### PR TITLE
Address PR feedback on ActiveRecord:QueryLogs:Formatter

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -143,7 +143,7 @@ module ActiveRecord
             else
               handler
             end
-            "#{key}#{self.formatter.key_value_separator}#{self.formatter.quote_value(val)}" unless val.nil?
+            "#{key}#{self.formatter.key_value_separator}#{self.formatter.format_value(val)}" unless val.nil?
           end.join(",")
         end
     end

--- a/activerecord/lib/active_record/query_logs_formatter.rb
+++ b/activerecord/lib/active_record/query_logs_formatter.rb
@@ -2,55 +2,43 @@
 
 module ActiveRecord
   module QueryLogs
-    class Formatter
+    class Formatter # :nodoc:
       attr_reader :key_value_separator
 
-      SUPPORTED_QUOTE_VALUES = %i[
-        none
-        single
-      ].freeze
       # @param [String] key_value_separator: indicates the string used for
       # separating keys and values.
       #
       # @param [Symbol] quote_values: indicates how values will be formatted (eg:
       # in single quotes, not quoted at all, etc)
-      def initialize(key_value_separator:, quote_values:)
-        unless SUPPORTED_QUOTE_VALUES.include?(quote_values)
-          raise ArgumentError, "Quote_values arg is unsupported: #{quote_values}"
-        end
+      def initialize(key_value_separator:)
         @key_value_separator = key_value_separator
-        @quote_values = quote_values
       end
 
       # @param [string] value
       # @return [String] The formatted value that will be used in our key-value
       # pairs.
-      def quote_value(value)
-        if @quote_values == :none
-          value
-        else
-          "'#{value.gsub("'", "\\\\'")}'"
-        end
+      def format_value(value)
+        value
       end
     end
 
-    class FormatterFactory
-      SUPPORTED_FORMATTERS = %i[
-            default
-            sqlcommenter
-          ].freeze
+    class QuotingFormatter < Formatter # :nodoc:
+      def format_value(value)
+        "'#{value.gsub("'", "\\\\'")}'"
+      end
+    end
 
+    class FormatterFactory # :nodoc:
       # @param [Symbol] formatter: the kind of formatter we're building.
       # @return [Formatter]
       def self.from_symbol(formatter)
-        unless SUPPORTED_FORMATTERS.include?(formatter)
-          raise ArgumentError, "Formatter is unsupported: #{formatter}"
-        end
-
-        if formatter == :default
-          Formatter.new(key_value_separator: ":", quote_values: :none)
+        case formatter
+        when :default
+          Formatter.new(key_value_separator: ":")
+        when :sqlcommenter
+          QuotingFormatter.new(key_value_separator: "=")
         else
-          Formatter.new(key_value_separator: "=", quote_values: :single)
+          raise ArgumentError, "Formatter is unsupported: #{formatter}"
         end
       end
     end

--- a/activerecord/test/cases/query_logs_formatter_test.rb
+++ b/activerecord/test/cases/query_logs_formatter_test.rb
@@ -9,19 +9,13 @@ class QueryLogsFormatter < ActiveRecord::TestCase
     end
     end
 
-  def test_factory_invalid_quote_values
-    assert_raises(ArgumentError) do
-      ActiveRecord::QueryLogs::Formatter.new(key_value_separator: ":", quote_values: :does_not_exist)
-    end
-  end
-
   def test_sqlcommenter_key_value_separator
     formatter = ActiveRecord::QueryLogs::FormatterFactory.from_symbol(:sqlcommenter)
     assert_equal("=", formatter.key_value_separator)
   end
 
-  def test_sqlcommenter_quote_value
+  def test_sqlcommenter_format_value
     formatter = ActiveRecord::QueryLogs::FormatterFactory.from_symbol(:sqlcommenter)
-    assert_equal("'Joe\\'s Crab Shack'", formatter.quote_value("Joe's Crab Shack"))
+    assert_equal("'Joe\\'s Crab Shack'", formatter.format_value("Joe's Crab Shack"))
   end
 end


### PR DESCRIPTION
This PR addresses the feedback in https://github.com/rails/rails/pull/45081

Note that this only addresses the inline comments, not the "big picture" feedback from the PR review:

>  One "big picture" question though: should all values be quoted? I see that you preserved the existing behavior, but is the existing behavior correct?

I still have to look into this.

But I think these changes are worth merging for now 😁 

## Testing

It doesn't look like I have permissions to run the full unit test suite in the CI from this PR:

> First-time contributors need a maintainer to approve running workflows.

But I verified that the unit tests and rubocop pass by running the following in the `activerecord` dir:

```
ARCONN=sqlite3 bundle exec ruby -Itest test/cases/query_logs_test.rb
ARCONN=sqlite3 bundle exec ruby -Itest test/cases/query_logs_formatter_test.rb

bundle exec rake test:sqlite3

bundle exec rubocop test/cases/query_logs_formatter_test.rb test/cases/query_logs_test.rb lib/active_record/query_logs_formatter.rb lib/active_record/query_logs.rb
```

and the following in the `railties` dir:

```
bundle exec ruby -Itest test/application/query_logs_test.rb
```

So I feel confident that this change won't break anything in the upstream Rails repo PR.